### PR TITLE
Move credit from title screen to startup screen

### DIFF
--- a/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
+++ b/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
@@ -93,6 +93,8 @@ namespace TJAPlayer3
                     this.list進行文字列.Add("");
                     this.list進行文字列.Add("TJAPlayer3 forked TJAPlayer2 forPC(kairera0467)");
                     this.list進行文字列.Add("TJAPlayer3 edited by AioiLight(@aioilight)");
+		    this.list進行文字列.Add("");
+		    this.list進行文字列.Add("TJAPlayer3-Develop initiated by touhou-renren(@ren43723591)");
                     this.list進行文字列.Add("");
 
                     es = new CEnumSongs();

--- a/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
+++ b/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
@@ -214,7 +214,7 @@ namespace TJAPlayer3
 #if DEBUG
                 TJAPlayer3.act文字コンソール.tPrint(4, 44, C文字コンソール.Eフォント種別.白, "DEBUG BUILD");
 #endif
-                TJAPlayer3.act文字コンソール.tPrint(4, (720 - 24), C文字コンソール.Eフォント種別.白, "TJAPlayer3-Develop Forked by touhou-renren(@ren43723591)");
+                TJAPlayer3.act文字コンソール.tPrint(4, (720 - 24), C文字コンソール.Eフォント種別.白, strCreator);
 				#endregion
 
 				TJAPlayer3.NamePlate.tNamePlateDraw(0, 0);


### PR DESCRIPTION
We should move credit from the title screen to the startup screen, in case of additional credit.
Also, the original position of credit(bottom left on the title screen) is now replaced with the repository URL to represent the whole project, rather than individuals.