### PR TITLE
Remove repository URL from the title screen

### DIFF
--- a/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
+++ b/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
@@ -227,7 +227,6 @@ namespace TJAPlayer3
 #if DEBUG
                 TJAPlayer3.act文字コンソール.tPrint(4, 44, C文字コンソール.Eフォント種別.白, "DEBUG BUILD");
 #endif
-                TJAPlayer3.act文字コンソール.tPrint(4, (720 - 32), C文字コンソール.Eフォント種別.白, strCreator);
 				#endregion
 
 				TJAPlayer3.NamePlate.tNamePlateDraw(0, 0);


### PR DESCRIPTION
Remove repository URL from the title screen since @KabanFriends made it in the startup screen.