### PR TITLE
DrawPrivateFont内での文字列の大きさ計算アルゴリズムを変更(Changed the algorithm for calculating string size in DrawPrivateFont.) #2

### DIFF
--- a/TJAPlayer3/Common/CPrivateFont.cs
+++ b/TJAPlayer3/Common/CPrivateFont.cs
@@ -326,6 +326,7 @@ namespace TJAPlayer3
 				System.Windows.Forms.TextFormatFlags.NoPrefix |
 				System.Windows.Forms.TextFormatFlags.NoPadding
 			);
+            stringSize.Height = _font.Height;
             stringSize.Width += 10; //2015.04.01 kairera0467 ROTTERDAM NATIONの描画サイズがうまくいかんので。
 
 			//取得した描画サイズを基に、描画先のbitmapを作成する
@@ -444,9 +445,10 @@ namespace TJAPlayer3
                 Size strSize = System.Windows.Forms.TextRenderer.MeasureText( strName[ i ], this._font, new Size( int.MaxValue, int.MaxValue ),
 				System.Windows.Forms.TextFormatFlags.NoPrefix |
 				System.Windows.Forms.TextFormatFlags.NoPadding );
+                strSize.Height = _font.Height;
 
                 //stringformatは最初にやっていてもいいだろう。
-			    StringFormat sFormat = new StringFormat();
+                StringFormat sFormat = new StringFormat();
 			    sFormat.LineAlignment = StringAlignment.Center;	// 画面下部（垂直方向位置）
 			    sFormat.Alignment = StringAlignment.Center;	// 画面中央（水平方向位置）
 
@@ -493,6 +495,7 @@ namespace TJAPlayer3
                 Size strSize = System.Windows.Forms.TextRenderer.MeasureText(strName[i], this._font, new Size(int.MaxValue, int.MaxValue),
                 System.Windows.Forms.TextFormatFlags.NoPrefix |
                 System.Windows.Forms.TextFormatFlags.NoPadding);
+                strSize.Height = _font.Height;
 
                 //stringformatは最初にやっていてもいいだろう。
                 StringFormat sFormat = new StringFormat();


### PR DESCRIPTION
## 日本語
OTJAP3DでPull requestしたものとも、また違うものです。

前回のPRでは、サイズを計るアルゴリズムを変更しましたが、
今回のPRはFontクラスのHeightプロパティをSizeのHeightプロパティに代入、上書きしているだけです。

しかし、[MSDN](https://docs.microsoft.com/ja-jp/dotnet/api/system.drawing.font.height)には、
>行間とは、2 つの連続するテキスト行のベース ライン間の垂直距離です。 このため、行間隔には、行の間の空白と文字自体の高さが含まれます。

と記述されており、取得したいのは文字自体の高さのみですが、行間の空白も加算され、取得されてしまいます。
ですが、行間の空白が加算されてしまうということは、文字自体が切れることはないに等しいと思われるため、PRいたします。
また、これならば、英字のみと日本語交じりの文字列で位置がずれることはないと思います。
(FontクラスのHeightプロパティはインスタンス生成をした段階で固定されると思われるため。)

私はFOT系のフォントを所持していないため、検証ができていません。
そのため、不具合が修正されているかわかりませんが、資料程度になれば幸いです。

## English
It's also different from the one I pulled request on OTJAP3D.

In my last PR, I changed the algorithm that measures the size
This PR is just substituting and overriding the Height property of the Font class for the Height property of Size.

However, the [MSDN](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.font.height) has a
> The line spacing is the vertical distance between the base lines of two consecutive lines of text. Thus, the line spacing includes the blank space between lines along with the height of the character itself.

So, although we only want to get the height of the characters, the brank space between the lines is also added to the line spacing.
However, the fact that the spaces between the lines are added means that the characters themselves will not be cut, so I will PR it.
Moreover, if this is the case, I think that the position does not shift in the string of only English letters and Japanese mixture.
(Because the height property of the Font class is supposed to be fixed at the stage of instantiation.)

I don't own any FOT fonts, so I haven't been able to verify this.
Therefore, I don't know whether the bug has been fixed or not, but I hope this is just a document.

Translated with www.DeepL.com/Translator (free version)