### PR TITLE
Fix title/subtitle rendering when skipping

### DIFF
--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -985,7 +985,7 @@ namespace TJAPlayer3
 						#endregion
 					}
 
-                    if(this.b選択曲が変更された && n現在のスクロールカウンタ == 0)
+                    if(this.b選択曲が変更された && n現在のスクロールカウンタ == 0　&& n目標のスクロールカウンタ == 0)
                     {
                         if (this.ttk選択している曲の曲名 != null)
                         {


### PR DESCRIPTION
Fixed an issue that was talked about in the #ask on the Discord server.

The cause of this issue is that the title updates before the scrolling is complete.