### PR TITLE
Score bug fix

### DIFF
--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -1792,7 +1792,7 @@ namespace TJAPlayer3
 						nAddScoreNiji2 = nAddScoreNiji / 2;
 						if(nAddScoreNiji2 % 2 == 1)
 						{
-						    nAddScoreNiji2 += 5;
+						    nAddScoreNiji2 -= 5;
 						}
 						
 					}


### PR DESCRIPTION
changed the score from +5 to -5 if the score ÷ 2 can't be devided by 10.
(1190÷2=595, you will get 590 points if you get 可)